### PR TITLE
fixed a missing div tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
 					<h1>Unhosted</h1>
 					<h2>Freedom from web 2.0's monopoly platforms</h2>
 					<p id="intro">
-						By &quot;unhosted web apps&quot; we mean
-              <strong>browser-based apps with no server-side backend</strong>.
+			By &quot;unhosted web apps&quot; we mean
+			<strong>browser-based apps with no server-side backend</strong>.
             Unlike server-side or client-server apps,
             unhosted web apps leave users in control of their valuable user data and privacy, by default.
-          </p>
+          			</p>
 					<p>
             <strong>Unhosted web apps</strong> are also more resilient and more scalable.
             Most importantly, unlike Apple/iOS, Flash, and Facebook apps,
@@ -101,7 +101,7 @@
 		</section><!-- end maincontent -->
 		<div class="clear"></div>
 		<footer>
-		 <div class="container_12">
+			<div class="container_16">
 				<div id="twitter">
 					<a href="http://twitter.com/unhosted" target="_blank" id="icon">Follow us! @Unhosted on Twitter</a>
 					<h4>Follow #unhosted on <a href="http://identi.ca/unhosted" target="_blank">identi.ca</a> or 
@@ -119,6 +119,7 @@
 					<h4>Participate</h4>
 					<p>The web as an app platform has <strong>no leaders</strong>, and this advocacy blog is an entirely altruistic and non-commercial initiative. <strong>If you want to help feed the conversation, please join</strong> <a href="http://groups.google.com/forum/#!forum/unhosted" target="_blank">the mailing list</a> and/or <a href="http://webchat.freenode.net/?channels=#unhosted" target="_blank">the chatroom</a>.</p>
 				</div>
+			</div>
 		</footer>
 		
 	</body>


### PR DESCRIPTION
i was trying to fix the footer, there text in the 'participate' div flows off the edge of the background image - this happens with chrome or firefox in linux. 

I couldn't fix it because the background images for the twitter and participate div boxes need to be enlarged vertically to be able to fit one more line of text, but my gimp skills aren't good enough to extend those images without it looking bad. :P

this little push is to fix a missing </div> close tag in the footer.
