### PR TITLE
increasing the nav ul elements' line-height to 

### DIFF
--- a/adventures/adventures.css
+++ b/adventures/adventures.css
@@ -24,5 +24,6 @@ nav div img { border-radius:5px }
 .logo { float:right; width:350px; text-align:center }
 nav .logo { float:right; width:250px; text-align:center }
 .logo img { margin:0 auto }
+nav ul { line-height: 1.2em }
 
 footer { clear:right; text-align:center; background-color:#EEE }


### PR DESCRIPTION
inherited line-height:0.6em from nav makes social network links be superimposed in Firefox (not in Chrome thanks to its user agent stylesheet)
=> proposing to set nav ul line-height:1.2em;
